### PR TITLE
edit README file, add instructions for developers to add .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Back-End Project Northcoders News API
+
+### You must add files .env.test and .env.development in order to successfully connect to the test and development databases locally.


### PR DESCRIPTION
Update README, add instructions explaining that developers must add .env.test and .env.development files to successfully connect to the two databases locally